### PR TITLE
Fix tool naming and add tools, add example.

### DIFF
--- a/examples/run_mcp.py
+++ b/examples/run_mcp.py
@@ -1,0 +1,66 @@
+"""Run the MCP server connected to non-empty local exchange."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from concurrent.futures import ProcessPoolExecutor
+
+from academy.agent import action
+from academy.agent import Agent
+from academy.exchange.cloud.client import spawn_http_exchange
+from academy.logging import init_logging
+from academy.manager import Manager
+from academy.socket import open_port
+
+from academy_extensions.mcp import mcp
+
+
+class SimulationAgent(Agent):
+    """This is a simulation agent."""
+
+    @action
+    async def ionization_energy(self, chemical: str) -> float:
+        """Simulates the ionization energy of molecule.
+
+        Args:
+            chemical: Molecule given as a SMILES string.
+
+        Returns:
+            The ionization energy in micro-joules
+        """
+        return 0.5
+
+
+async def main() -> None:
+    """Run example MCP server.
+
+    This script does three things to create an isolated running MCP:
+    1. Launches a local HTTP exchange
+    2. Populates the exchange with an agent.
+    3. Starts the academy-mcp connected to the local exchange.
+    This allows an example MCP server to run without querying the cloud
+    exchange.
+    """
+    init_logging()
+
+    with spawn_http_exchange(
+        host='0.0.0.0',
+        port=open_port(),
+    ) as exchange_factory:
+        async with await Manager.from_exchange_factory(
+            factory=exchange_factory,
+            executors=ProcessPoolExecutor(
+                max_workers=1,
+                initializer=init_logging,
+            ),
+        ) as manager:
+            os.environ['ACADEMY_MCP_EXCHANGE_ADDRESS'] = (
+                exchange_factory._info.url
+            )
+            await manager.launch(SimulationAgent)
+            await mcp.run_sse_async()
+
+
+if __name__ == '__main__':
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
# Description
Tool naming was incompatible with Claude MCP client because of the use of "<". Furthermore, Claude got confused by the add tool method not returning anything. These were found using the example `run_mcp.py` script.


### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
Tested with Claude desktop

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
